### PR TITLE
Fix checksum computation if using PID greater or equal than 0x3C

### DIFF
--- a/src/LINAnalyzer.cpp
+++ b/src/LINAnalyzer.cpp
@@ -112,8 +112,8 @@ void LINAnalyzer::WorkerThread()
 
 					bool classic_identifier = false;
 					U8 identifier = byteFrame.mData1 & 0x3F;
-					if( identifier == 0x3C || identifier == 0x3D )
-						classic_identifier == true;
+					if( identifier >= 0x3C )
+						classic_identifier = true;
 
 					mChecksum.clear();
 					if( mSettings->mLINVersion >= 2 && classic_identifier == false )


### PR DESCRIPTION
As per LIN 2.0 specification section 2.1.5, "Identifiers 60 (0x3c)
to 63 (0x3f) shall always use classic checksum."

Signed-off-by: Francois Berder <18538310+francois-berder@users.noreply.github.com>