### PR TITLE
useframev2

### DIFF
--- a/src/LINAnalyzer.cpp
+++ b/src/LINAnalyzer.cpp
@@ -37,6 +37,7 @@ LINAnalyzer::LINAnalyzer()
     : Analyzer2(), mSettings( new LINAnalyzerSettings() ), mSimulationInitilized( false ), mFrameState( LINAnalyzerResults::NoFrame )
 {
     SetAnalyzerSettings( mSettings.get() );
+    UseFrameV2();
 }
 
 LINAnalyzer::~LINAnalyzer()


### PR DESCRIPTION
This won't build until the new UseFrameV2(); Function has become an official part of the SDK. In the meantime, do not use `UseFrameV2();`, as it will fail to build.